### PR TITLE
Check if file exists before sending the GET request

### DIFF
--- a/glide_text2im/download.py
+++ b/glide_text2im/download.py
@@ -34,12 +34,12 @@ def fetch_file_cached(
     if cache_dir is None:
         cache_dir = default_cache_dir()
     os.makedirs(cache_dir, exist_ok=True)
+    local_path = os.path.join(cache_dir, url.split("/")[-1])
+    if os.path.exists(local_path):
+        return local_path
     response = requests.get(url, stream=True)
     size = int(response.headers.get("content-length", "0"))
-    local_path = os.path.join(cache_dir, url.split("/")[-1])
     with FileLock(local_path + ".lock"):
-        if os.path.exists(local_path):
-            return local_path
         if progress:
             pbar = tqdm(total=size, unit="iB", unit_scale=True)
         tmp_path = local_path + ".tmp"


### PR DESCRIPTION
The function `fetch_file_cached` call `requests.get` before checking if the file was already present, which caused it to raise an exception for offline use.

This PR simply moves the check before the call to `requests`.