### PR TITLE
added missing required package to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "tqdm",
         "ftfy",
         "regex",
+        "numpy",
     ],
     author="OpenAI",
 )


### PR DESCRIPTION
Several files import numpy, but it's not included in the setup requirements. In a fresh virtual environment the project fails to run after installing with `pip install -e .`.