### PR TITLE
Fix NumPy Deprecation Warning for np.bool Usage in attention.py

### DIFF
--- a/glide_text2im/clip/attention.py
+++ b/glide_text2im/clip/attention.py
@@ -108,7 +108,7 @@ class DenseCausalAttentionMask(AttentionMask):
     def __attrs_post_init__(self) -> None:
         super().__attrs_post_init__()
 
-        self.global_layout = np.tril(np.ones([self.n_query_block, self.n_key_block], dtype=np.bool))
+        self.global_layout = np.tril(np.ones([self.n_query_block, self.n_key_block], dtype=np.bool_))
         n_zero_query_blocks = self.n_query_pad // self.block_size
         n_zero_key_blocks = self.n_key_pad // self.block_size
         self.global_layout[self.n_query_block - n_zero_query_blocks :] = False

--- a/glide_text2im/clip/attention.py
+++ b/glide_text2im/clip/attention.py
@@ -39,13 +39,13 @@ class AttentionMask(ABC):
 
     def _make_global_layout(self) -> None:
         if not self.is_head_specific:
-            m = np.ones([self.n_query_block, self.n_key_block], dtype=np.bool)
+            m = np.ones([self.n_query_block, self.n_key_block], dtype=np.bool_)
             r = product(*[range(n) for n in m.shape])
 
             for qb, kb in r:
                 m[qb, kb] = np.any(self.block_layout(None, 0, qb, kb, 0))
         else:
-            m = np.ones([self.n_head, self.n_query_block, self.n_key_block], dtype=np.bool)
+            m = np.ones([self.n_head, self.n_query_block, self.n_key_block], dtype=np.bool_)
             r = product(*[range(n) for n in m.shape])
 
             for h, qb, kb in r:
@@ -66,7 +66,7 @@ class AttentionMask(ABC):
         `query_idx`, `key_idx` are block-level, zero-based indices.
         """
 
-        m = np.ones([self.block_size, self.block_size], dtype=np.bool)
+        m = np.ones([self.block_size, self.block_size], dtype=np.bool_)
 
         if query_idx >= self.first_pad_query_block_idx:
             n_pad = min(
@@ -91,7 +91,7 @@ class DenseAttentionMask(AttentionMask):
     def __attrs_post_init__(self) -> None:
         super().__attrs_post_init__()
 
-        self.global_layout = np.ones([self.n_query_block, self.n_key_block], dtype=np.bool)
+        self.global_layout = np.ones([self.n_query_block, self.n_key_block], dtype=np.bool_)
         n_zero_query_blocks = self.n_query_pad // self.block_size
         n_zero_key_blocks = self.n_key_pad // self.block_size
         self.global_layout[self.n_query_block - n_zero_query_blocks :] = False
@@ -100,7 +100,7 @@ class DenseAttentionMask(AttentionMask):
     def _block_layout(
         self, blk_shape: Any, head_idx: int, query_idx: int, key_idx: int, blk_idx: int
     ) -> np.ndarray:
-        return np.ones([self.block_size, self.block_size], dtype=np.bool)
+        return np.ones([self.block_size, self.block_size], dtype=np.bool_)
 
 
 @attr.s
@@ -108,7 +108,7 @@ class DenseCausalAttentionMask(AttentionMask):
     def __attrs_post_init__(self) -> None:
         super().__attrs_post_init__()
 
-        self.global_layout = np.tril(np.ones([self.n_query_block, self.n_key_block], dtype=np.bool_))
+        self.global_layout = np.tril(np.ones([self.n_query_block, self.n_key_block], dtype=np.bool__))
         n_zero_query_blocks = self.n_query_pad // self.block_size
         n_zero_key_blocks = self.n_key_pad // self.block_size
         self.global_layout[self.n_query_block - n_zero_query_blocks :] = False
@@ -118,11 +118,11 @@ class DenseCausalAttentionMask(AttentionMask):
         self, blk_shape: Any, head_idx: int, query_idx: int, key_idx: int, blk_idx: int
     ) -> np.ndarray:
         if query_idx > key_idx:
-            return np.ones(2 * [self.block_size], dtype=np.bool)
+            return np.ones(2 * [self.block_size], dtype=np.bool_)
         elif query_idx < key_idx:
-            return np.zeros(2 * [self.block_size], dtype=np.bool)
+            return np.zeros(2 * [self.block_size], dtype=np.bool_)
         else:
-            return np.tril(np.ones(2 * [self.block_size], dtype=np.bool))
+            return np.tril(np.ones(2 * [self.block_size], dtype=np.bool_))
 
 
 @attr.s(eq=False, repr=False)

--- a/glide_text2im/clip/attention.py
+++ b/glide_text2im/clip/attention.py
@@ -108,7 +108,7 @@ class DenseCausalAttentionMask(AttentionMask):
     def __attrs_post_init__(self) -> None:
         super().__attrs_post_init__()
 
-        self.global_layout = np.tril(np.ones([self.n_query_block, self.n_key_block], dtype=np.bool__))
+        self.global_layout = np.tril(np.ones([self.n_query_block, self.n_key_block], dtype=np.bool_))
         n_zero_query_blocks = self.n_query_pad // self.block_size
         n_zero_key_blocks = self.n_key_pad // self.block_size
         self.global_layout[self.n_query_block - n_zero_query_blocks :] = False


### PR DESCRIPTION
### Problem Description

The glide_text2im package currently uses np.bool in attention.py, which has been deprecated since NumPy 1.20. This results in a FutureWarning when using the package and eventually leads to an AttributeError in environments with NumPy versions that have fully removed the np.bool alias.

### Proposed Solution

This pull request replaces all instances of np.bool with np.bool_ in the attention.py file. The np.bool_ data type is the recommended replacement for np.bool and is not deprecated. This change ensures compatibility with current and future versions of NumPy without altering the functionality of the glide_text2im package.

### Justification

Using np.bool_ ensures that the package remains functional and free of deprecation warnings and errors with NumPy 1.20 and later. This update is necessary to maintain the package's usability in current and future Python environments, fostering a smoother user experience and compatibility with the wider Python ecosystem.

### Testing

The modifications have been tested locally to verify that the FutureWarning is resolved and that the glide_text2im package functions as expected with the change. All existing tests pass, and no new functionality has been introduced, minimizing the risk of side effects.

I look forward to your feedback on this pull request. Thank you for maintaining the glide_text2im package and for considering this update to ensure its continued compatibility and performance.